### PR TITLE
services: Add custom labels for to-client mode case.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ clients:
       port: 6444
       endpoint: services:443
       servicePort: 443
+      labels:
+        company/blackbox_monitoring: true
 - user: sample2
   password: sample2se"e'$acret
   services:
@@ -250,6 +252,7 @@ For each service name / key an array of services can be defined. Each service de
 | `servicePort` | The port this service should be exposed on the service object. Defaults to `port` if omitted. |
 | `endpoint` | The destination to which chisel forwards this service. **required** |
 | `name` | Custom name of this service within the service |
+| `labels` | Custom labels for to-client services. Optional for selecting services (e.g monitoring). |
 | `serviceType` | Only valid on first entry: Sets `type` for the kubernetes service definition. Defaults to `ClusterIP` |
 | `clusterIP` | Only valid on first entry: Sets `clusterIP` on the kubernetes service definition when `type=LoadBalancer` |
 | `loadBalancerIP` | Only valid on first entry: Sets `loadBalancerIP` on the kubernetes service definition when `type=LoadBalancer` |

--- a/chisel/templates/service.yaml
+++ b/chisel/templates/service.yaml
@@ -82,6 +82,13 @@ metadata:
   name: {{ $opdata.serviceObjName }}
   labels:
     {{- $chiselLabels }}
+    {{- range $ports }}
+    {{- if .labels }}
+    {{- range $key, $value := .labels }}
+    {{ printf "%s: %v" $key $value }}
+    {{- end }}
+    {{- end }}
+    {{- end }}
 spec:
  {{- with (first $ports) }}{{- /* service settings are taken from first port entry */ -}}
   {{- $type := default "ClusterIP" .serviceType }}

--- a/chisel/values.yaml
+++ b/chisel/values.yaml
@@ -38,6 +38,7 @@ service:
   port: 80
 
 ingress:
+  host: example.domain.com
   enabled: true
   nginxRewrite: false
   annotations: {}


### PR DESCRIPTION
This is useful for selecting services for special purposes like monitoring.